### PR TITLE
refactor: fecha a integração do monorepo e põe packages/ sob o lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,10 @@ const eslintConfig = defineConfig([
     "**/out/**",
     "**/build/**",
     "**/next-env.d.ts",
+    // Mockups de design versionados fora do git (`.gitignore:43`). Não são
+    // código-fonte do app; sozinhos respondiam por 14 dos 36 achados quando o
+    // lint passou a varrer a raiz.
+    "docs/design-refactor/**",
   ]),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "start": "turbo start",
-    "lint": "turbo lint",
+    "lint": "eslint .",
     "typecheck": "turbo typecheck",
     "codegen": "pnpm --filter @recomenda/api codegen"
   },

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,7 +1,3 @@
-// Declarados em `lib/http/types` (camada de baixo). Re-exportados aqui para os
-// consumidores que já importam deste caminho.
-export type { ApiError, ApiErrorPayload } from "./http/types";
-
 export interface Pagination {
   page: number;
   page_size: number;


### PR DESCRIPTION
Última limpeza da migração: nenhum pacote se move aqui.

- remove o re-export de ApiError/ApiErrorPayload em @recomenda/api/types, herdado do A0. Tinha zero consumidores — o único uso real é o interceptor do axios, que já importa da origem em http/types. Os tipos seguem públicos por @recomenda/api/http/types.

- `pnpm lint` passa a varrer o repo inteiro (era `turbo lint`, que só achava script de lint em `web` e deixava ~6.500 linhas de packages/ fora do gate). A config já é flat e mora na raiz, então bastou apontar o script para lá — sem dependência nova nem script por pacote.

  Isso revela 4 achados pré-existentes que nunca tinham sido medidos, entre eles um erro em packages/api introduzido pelo A3. Baseline real: 22 (6 erros, 16 warnings), não os 21 registrados pelo A6. Nenhum corrigido — A7 não mexe em código de componente.

- ignora docs/design-refactor no eslint: mockups de design gitignored que respondiam por 14 dos 36 achados brutos ao varrer a raiz.

Verificação: `main` (pré-monorepo) e esta branch rodados lado a lado contra o mesmo backend — 24 telas com innerText byte a byte idêntico e documento de impressão idêntico. Os números do baseline do A4 conferem nas 5 fazendas.

Pendente antes do merge: deploy de preview (Root Directory precisa virar apps/web) e a UI de admin, não exercitada porque a conta de teste é AGRONOMIST.